### PR TITLE
[Add] hirbの導入 #28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ er.drawio
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+.irb_history

--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,11 @@
+# コンソール起動時
+if defined? Rails::Console
+# Hirb.enableの有効性
+  if defined? Hirb
+    # hirbをオン
+    Hirb.enable
+    # hirbをオフ
+    # Hirb.disable
+  end
+
+end

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'factory_bot_rails'
   gem 'pry-byebug'
+  gem 'hirb'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
       sassc (>= 1.11)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hirb (0.7.3)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
@@ -306,6 +307,7 @@ DEPENDENCIES
   byebug
   factory_bot_rails
   font-awesome-sass
+  hirb
   jbuilder (~> 2.7)
   jquery-rails
   listen (~> 3.3)


### PR DESCRIPTION
- hirb導入
- .irb_historyを.gitignoreに追加

ネットの記事にあるような、gem `hirb-unicode-steakknife`や`hirb-unicord`をインストールすると不具合が生じたので`git reset --hard HEAD^`して取り消し後、`hirb`のみインストールすることでうまくいった。
また、`.irb-history`というファイルが生成されたので、gitの管轄から外した。
a69664621590a9f8f03f561571dc586a0a4c3938
