### PR TITLE
[Add] production環境のdefault_url_optionsの設定を変更 #75

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,2 +1,3 @@
 default_url_options:
-  host: 'localhost'
+  protcol: 'https'
+  host: 'reptileslog.com'


### PR DESCRIPTION
## 概要
前回のコミットではリセットパスワード申請は成功しメールが送信されましたが、再発行リンクからアクセスできませんでした。
再発行リンクは以下のような形
`https://localhost/password_resets/文字列/edit `
[こちらの記事](https://skillhub.jp/courses/137/lessons/977)を参考にし、
下記コミットで変更を追加。
6644071bb11a11ffa334c7a6d99d9f4d47096987