### PR TITLE
add: macOS Montereyに対するPlatform指定

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1665,6 +1665,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
## 概要
MacStudio購入後、そちらから管理をするためにgit cloneした。
環境構築後、macOS Montereyに対するPlatform指定が追加された。
